### PR TITLE
Remove the underline from spoiler text

### DIFF
--- a/scss/_markdown.scss
+++ b/scss/_markdown.scss
@@ -133,6 +133,7 @@
   a[href$="/spoiler"] {
     background: $spoiler-bg !important;
     color: $spoiler-bg !important;
+    text-decoration: none;
     &:hover {
       color: $spoiler-fg !important;
     }


### PR DESCRIPTION
This removes the underline from spoiler text (which isn't meant to be a link).
